### PR TITLE
Admin: AYON commands

### DIFF
--- a/website/docs/admin_ayon_commands.md
+++ b/website/docs/admin_ayon_commands.md
@@ -14,17 +14,9 @@ Running AYON without any commands will default to `tray`.
 :::
 
 ## Common arguments
-`--use-version` to specify explicit version to use:
-```shell
-openpype_console --use-version=3.0.0-foo+bar
-```
 `--headless` - to run AYON in headless mode (without using graphical UI)
 
 `--use-staging` - to use staging versions of AYON.
-
-`--list-versions` - to list available versions.
-
-`--validate-version` - to validate integrity of given version
 
 `--verbose` `<level>` - change log verbose level of AYON loggers
 
@@ -38,41 +30,17 @@ For more information [see here](admin_use.md#run-ayon).
 | --- | --- |: --- :|
 | contextselection | Open Context selection dialog. |  |
 | module | Run command line arguments for modules. |  |
-| repack-version | Tool to re-create version zip. | [📑](#repack-version-arguments) |
 | tray | Launch AYON Tray. | [📑](#tray-arguments)
-| launch | Launch application in AYON environment. | [📑](#launch-arguments) |
 | publish | AYON takes JSON from provided path and use it to publish data in it. | [📑](#publish-arguments) |
 | extractenvironments | Extract environment variables for entered context to a json file. | [📑](#extractenvironments-arguments) |
 | run | Execute given python script within AYON environment. | [📑](#run-arguments) |
 | interactive | Start python like interactive console session. | |
-| projectmanager | Launch Project Manager UI | [📑](#projectmanager-arguments) |
-| settings | Open Settings UI | [📑](#settings-arguments) |
 
 ---
 ### `tray` arguments {#tray-arguments}
 
 ```shell
 openpype_console tray
-```
----
-
-### `launch` arguments {#launch-arguments}
-
-| Argument | Description |
-| --- | --- |
-| `--app` | Application name - this should be the key for application from Settings. |
-| `--project` | Project name (default taken from `AVALON_PROJECT` if set) |
-| `--asset` | Asset name (default taken from `AVALON_ASSET` if set) |
-| `--task` | Task name (default taken from `AVALON_TASK` is set) |
-| `--tools` | *Optional: Additional tools to add* |
-| `--user` | *Optional: User on behalf to run* |
-| `--ftrack-server` / `-fs` | *Optional: Ftrack server URL* |
-| `--ftrack-user` / `-fu` | *Optional: Ftrack user* |
-| `--ftrack-key` / `-fk` | *Optional: Ftrack API key* |
-
-For example to run Python interactive console in Pype context:
-```shell
-pype launch --app python --project my_project --asset my_asset --task my_task
 ```
 
 ---
@@ -119,31 +87,4 @@ Note that additional arguments are passed to the script.
 
 ```shell
 openpype_console run --script /foo/bar/baz.py arg1 arg2
-```
-
----
-### `projectmanager` arguments {#projectmanager-arguments}
-`projectmanager` has no command-line arguments.
-```shell
-openpype_console projectmanager
-```
-
----
-### `settings` arguments {#settings-arguments}
-
-| Argument | Description |
-| `-d` / `--dev` | Run settings in developer mode. |
-
-```shell
-openpype_console settings
-```
-
----
-### `repack-version` arguments {#repack-version-arguments}
-Takes path to unzipped and possibly modified AYON version. Files will be
-zipped, checksums recalculated and version will be determined by folder name
-(and written to `version.py`).
-
-```shell
-./openpype_console repack-version /path/to/some/modified/unzipped/version/openpype-v3.8.3-modified
 ```

--- a/website/docs/admin_ayon_commands.md
+++ b/website/docs/admin_ayon_commands.md
@@ -5,24 +5,24 @@ sidebar_label: AYON Commands
 ---
 
 :::info
-You can substitute `ayon` with `poetry run python ayon_start.py` if you want to run it
-directly from sources.
+You can substitute `ayon` with `poetry run python ayon_start.py` if you want to run it directly from sources.
 :::
 
 :::note
 Running AYON without any commands will default to `tray`.
 :::
 
-## Common arguments
-`--headless` - to run AYON in headless mode (without using graphical UI)
+## Common Arguments
+
+`--headless` - to run AYON in headless mode (without using graphical UI).
 
 `--use-staging` - to use staging versions of AYON.
 
-`--verbose` `<level>` - change log verbose level of AYON loggers
+`--verbose` `<level>` - change the log verbose level of AYON loggers.
 
-`--debug` - set debug flag affects logging
+`--debug` - set the debug flag, which affects logging.
 
-For more information [see here](admin_use.md#run-ayon).
+For more information, [see here](admin_use.md#run-ayon).
 
 ## Commands
 
@@ -31,26 +31,28 @@ For more information [see here](admin_use.md#run-ayon).
 | contextselection | Open Context selection dialog. | [📑](#contextselection-arguments) |
 | module | Run command line arguments of addons/modules. | |
 | tray | Launch AYON Tray. | [📑](#tray-arguments) |
-| publish | AYON takes JSON from provided path and use it to publish data in it. | [📑](#publish-arguments) |
-| extractenvironments | Extract environment variables for entered context to a json file. | [📑](#extractenvironments-arguments) |
-| run | Execute given python script within AYON environment. | [📑](#run-arguments) |
-| interactive | Start python like interactive console session. | |
+| publish | AYON takes JSON from the provided path and uses it to publish data in it. | [📑](#publish-arguments) |
+| extractenvironments | Extract environment variables for the entered context to a JSON file. | [📑](#extractenvironments-arguments) |
+| run | Execute the given Python script within AYON environment. | [📑](#run-arguments) |
+| interactive | Start Python-like interactive console session. | |
 
 ---
-### `tray` arguments {#tray-arguments}
+
+### `tray` Arguments {#tray-arguments}
 
 ```shell
 ayon tray
 ```
 
 ---
-### `contextselection` arguments {#contextselection-arguments}
+
+### `contextselection` Arguments {#contextselection-arguments}
 | Argument | Description |
 | --- | --- |
-| `output_json_path` | Path to a json file where output will be stored. |
-| `--project` | Pre-define project context. Project cannot be changed when passed. |
-| `--asset` | Pre-define asset in project. Project must be passed. |
-| `--strict` | Full context must be set, or dialog cannot be confirmed. |
+| `output_json_path` | Path to a JSON file where the output will be stored. |
+| `--project` | Pre-define project context. The project cannot be changed when passed. |
+| `--asset` | Pre-define asset in the project. The project must be passed. |
+| `--strict` | The full context must be set, or the dialog cannot be confirmed. |
 
 **Example output:**
 ```json
@@ -66,33 +68,35 @@ ayon contextselection <PATH_TO_JSON>
 ```
 
 ---
-### `publish` arguments {#publish-arguments}
 
-Run publishing based on metadata passed in json file e.g. on farm.
+### `publish` Arguments {#publish-arguments}
+
+Run publishing based on metadata passed in the JSON file, for example, on a farm.
 
 | Argument | Description |
 | --- | --- |
-| `--targets` | define publishing targets (e.g. "farm") |
-| `--gui` (`-g`) | Show publishing |
-| Positional argument | Path to metadata json file |
+| `--targets` | Define publishing targets (e.g., "farm"). |
+| `--gui` (`-g`) | Show publishing. |
+| Positional argument | Path to metadata JSON file. |
 
 ```shell
 ayon publish <PATH_TO_JSON> --targes farm
 ```
 
 ---
-### `extractenvironments` arguments {#extractenvironments-arguments}
 
-Entered output filepath will be created if does not exists.
-All context options must be passed otherwise only ayon's global environments will be extracted.
-Context options are `project`, `asset`, `task`, `app`
+### `extractenvironments` Arguments {#extractenvironments-arguments}
+
+The entered output filepath will be created if it does not exist. 
+All context options must be passed; otherwise, only AYON's global environments will be extracted.
+Context options are `project`, `asset`, `task`, `app`.
 
 | Argument | Description |
 | --- | --- |
-| `output_json_path` | Absolute path to the exported json file |
-| `--project` | Project name |
-| `--asset` | Asset name |
-| `--task` | Task name |
+| `output_json_path` | Absolute path to the exported JSON file. |
+| `--project` | Project name. |
+| `--asset` | Asset name. |
+| `--task` | Task name. |
 | `--app` | Application name |
 
 ```shell

--- a/website/docs/admin_ayon_commands.md
+++ b/website/docs/admin_ayon_commands.md
@@ -27,10 +27,10 @@ For more information [see here](admin_use.md#run-ayon).
 ## Commands
 
 | Command | Description | Arguments |
-| --- | --- |: --- :|
-| contextselection | Open Context selection dialog. |  |
-| module | Run command line arguments for modules. |  |
-| tray | Launch AYON Tray. | [📑](#tray-arguments)
+| --- | --- | --- |
+| contextselection | Open Context selection dialog. | [📑](#contextselection-arguments) |
+| module | Run command line arguments of addons/modules. | |
+| tray | Launch AYON Tray. | [📑](#tray-arguments) |
 | publish | AYON takes JSON from provided path and use it to publish data in it. | [📑](#publish-arguments) |
 | extractenvironments | Extract environment variables for entered context to a json file. | [📑](#extractenvironments-arguments) |
 | run | Execute given python script within AYON environment. | [📑](#run-arguments) |
@@ -41,6 +41,28 @@ For more information [see here](admin_use.md#run-ayon).
 
 ```shell
 ayon tray
+```
+
+---
+### `contextselection` arguments {#contextselection-arguments}
+| Argument | Description |
+| --- | --- |
+| `output_json_path` | Path to a json file where output will be stored. |
+| `--project` | Pre-define project context. Project cannot be changed when passed. |
+| `--asset` | Pre-define asset in project. Project must be passed. |
+| `--strict` | Full context must be set, or dialog cannot be confirmed. |
+
+**Example output:**
+```json
+{
+    "project": "OP01_CG_Demo",
+    "asset": "robot",
+    "task": "modeling"
+}
+```
+
+```shell
+ayon contextselection <PATH_TO_JSON> 
 ```
 
 ---

--- a/website/docs/admin_ayon_commands.md
+++ b/website/docs/admin_ayon_commands.md
@@ -5,7 +5,7 @@ sidebar_label: AYON Commands
 ---
 
 :::info
-You can substitute `openpype_console` with `poetry run python start.py` if you want to run it
+You can substitute `ayon` with `poetry run python ayon_start.py` if you want to run it
 directly from sources.
 :::
 
@@ -40,7 +40,7 @@ For more information [see here](admin_use.md#run-ayon).
 ### `tray` arguments {#tray-arguments}
 
 ```shell
-openpype_console tray
+ayon tray
 ```
 
 ---
@@ -55,7 +55,7 @@ Run publishing based on metadata passed in json file e.g. on farm.
 | Positional argument | Path to metadata json file |
 
 ```shell
-pype publish <PATH_TO_JSON> --targes farm
+ayon publish <PATH_TO_JSON> --targes farm
 ```
 
 ---
@@ -74,7 +74,7 @@ Context options are `project`, `asset`, `task`, `app`
 | `--app` | Application name |
 
 ```shell
-openpype_console /home/openpype/env.json --project Foo --asset Bar --task modeling --app maya-2019
+ayon /home/openpype/env.json --project Foo --asset Bar --task modeling --app maya-2019
 ```
 
 ---
@@ -86,5 +86,5 @@ openpype_console /home/openpype/env.json --project Foo --asset Bar --task modeli
 Note that additional arguments are passed to the script.
 
 ```shell
-openpype_console run --script /foo/bar/baz.py arg1 arg2
+ayon run --script /foo/bar/baz.py arg1 arg2
 ```


### PR DESCRIPTION
## Description
Removed commands that don't have equivalent in AYON, change executable from `openpype_console` (and `pype`) to `ayon` and added arguments docs for `contextselection` command.

Removed commands `launch`, `repack-version`, `projectmanager` and `settings`. Removed global arguments `--use-version`, `--list-versions` and `--validate-version`.