### PR TITLE
user docs of the 3dsmax addon is being redirected correctly

### DIFF
--- a/website/src/data/addons/data/3dsmax.ts
+++ b/website/src/data/addons/data/3dsmax.ts
@@ -26,7 +26,7 @@ const addon: Addon = {
     ],
     docs: {
         user: "artist_hosts_3dsmax",
-        admin: "admin_hosts_Houdini",
+        admin: "admin_hosts_houdini",
     },
     github: "https://github.com/ynput/OpenPype/tree/develop/openpype/hosts/houdini",
 };

--- a/website/src/data/addons/data/3dsmax.ts
+++ b/website/src/data/addons/data/3dsmax.ts
@@ -28,7 +28,7 @@ const addon: Addon = {
         user: "artist_hosts_3dsmax",
         admin: "admin_hosts_houdini",
     },
-    github: "https://github.com/ynput/OpenPype/tree/develop/openpype/hosts/houdini",
+    github: "https://github.com/ynput/OpenPype/tree/develop/openpype/hosts/max",
 };
 
 export default addon;

--- a/website/src/data/addons/data/3dsmax.ts
+++ b/website/src/data/addons/data/3dsmax.ts
@@ -25,8 +25,8 @@ const addon: Addon = {
         "maxScene",
     ],
     docs: {
-        user: "artist_hosts_houdini",
-        admin: "admin_hosts_houdini",
+        user: "artist_hosts_3dsmax",
+        admin: "admin_hosts_Houdini",
     },
     github: "https://github.com/ynput/OpenPype/tree/develop/openpype/hosts/houdini",
 };


### PR DESCRIPTION
this PR makes sure the "user docs" from 3dsmax addon page directing to the 3dsmax user documentation 
(But where is the admin docs?)
![image](https://user-images.githubusercontent.com/64118225/233047631-3b9ea1e2-f169-4edc-a9ab-8e6288c09023.png)
