### PR TITLE
Docs broken link

### DIFF
--- a/website/docs/artist_tools_inventory.md
+++ b/website/docs/artist_tools_inventory.md
@@ -15,7 +15,7 @@ To use it go to **AYON** Menu > **Manage**  which opens **Inventory** for use.
 ![tools_inventory_01](assets/tools/tools_inventory_01.png)
 
 :::note
-Understanding [Key concepts](artist_concepts) and being aware of AYON terminology is a neccessity to be able to use this tool fully.
+Understanding [Key concepts](artist_concepts.md) and being aware of AYON terminology is a neccessity to be able to use this tool fully.
 :::
 
 Here is a small demo of a usage in Maya DCC host and where to locate it and its basics:

--- a/website/docs/system_introduction.md
+++ b/website/docs/system_introduction.md
@@ -13,7 +13,7 @@ To use AYON, you need to install both the server and the launcher app. Pre-built
 
 ## Studio Preparation
 
-You can find a detailed breakdown of technical requirements [here](dev_requirements), but in general, AYON should be able to operate in most studios fairly quickly. The main obstacles are usually related to workflows and habits that may not be fully compatible with what AYON expects or enforces. It is recommended to go through the [key concepts](artist_concepts) for artists to get comfortable with the basics.
+You can find a detailed breakdown of technical requirements [here](dev_requirements.md), but in general, AYON should be able to operate in most studios fairly quickly. The main obstacles are usually related to workflows and habits that may not be fully compatible with what AYON expects or enforces. It is recommended to go through the [key concepts](artist_concepts.md) for artists to get comfortable with the basics.
 
 Keep in mind that if you run into any workflows that are not supported, it is usually because AYON has not encountered that particular case and it can likely be added upon request.
 


### PR DESCRIPTION
## Changelog Description
Fix some broken links.

## Additional Info: explaining the bug
The bug was weird to me.
on my side, It only happened on chrome while the current URL was pointing to a particular section. 
So, nothing happens if the URL is https://ayon.ynput.io/docs/system_introduction and you try to click the two links `here` and `key concepts` 
but, it fails if the URL is https://ayon.ynput.io/docs/system_introduction/#studio-preparation and you try to click any of the two links `here` and `key concepts` 

Here's a screengrab to show the bug. 

![Animation_61](https://github.com/ynput/ayon-documentation/assets/20871534/231af7fb-bce9-4d05-be3a-bf9c8fe06e10)
