### PR TITLE
Update OTIO license in dev_requirements.md

### DIFF
--- a/website/docs/dev_requirements.md
+++ b/website/docs/dev_requirements.md
@@ -62,7 +62,7 @@ AYON uses [Poetry](https://python-poetry.org/) to handle the dependencies, and y
 | Compatible  | Package                  | License(s)                                                           |
 | ----------- | ------------------------ | -------------------------------------------------------------------- |
 | ✔          | Deprecated               | MIT License                                                          |
-| ✖          | OpenTimelineIO           | Other/Proprietary License                                            |
+| ✖          | OpenTimelineIO           | Apache Software License                                              |
 | ✔          | SecretStorage            | BSD License                                                          |
 | ✖          | Unidecode                | GNU General Public License v2 or later (GPLv2+)                      |
 | ✔          | acre                     | GNU LESSER GENERAL PUBLIC LICENSE Version 3                          |


### PR DESCRIPTION
Updated the OpenTimelineIO license in the requirements table.

## Changelog Description
Documentation fix.

## Additional info
OTIO used to be licensed under a "modified" Apache license, but was re-licensed to use the standard Apache License 2.0 in May 2022. For more info see this change: https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/1285

## Testing notes:
n/a
