### PR TITLE
add link to python api docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -113,6 +113,11 @@ const config = {
                         position: "left",
                     },
                     {
+                        href: "https://ynput.github.io/ayon-python-api/build/html/ayon_api.html",
+                        label: "Python API Docs",
+                        position: "left",
+                    },
+                    {
                         label: "Addons",
                         position: "right",
                         items: [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -113,7 +113,7 @@ const config = {
                         position: "left",
                     },
                     {
-                        href: "https://ynput.github.io/ayon-python-api/build/html/ayon_api.html",
+                        href: "https://ynput.github.io/ayon-python-api/",
                         label: "Python API Docs",
                         position: "left",
                     },


### PR DESCRIPTION
## Changelog Description
Add link to python api docs

![image](https://github.com/user-attachments/assets/bf3fdb28-35e3-4584-bf71-405ce1d733b1)


## Testing notes:

1. run docs
2. click the link
