### PR TITLE
Fix doc build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ If you spot something incorrect or just think a page could do with some improvem
 
 - Install Node.js https://nodejs.org/en/download
 - `npm install -g yarn`
-- `yarn add docusaurus --dev`
 - `cd {ayon-doc-repo}/website`
+- `yarn install`
 - `yarn start`
 
 ## Addons


### PR DESCRIPTION
## Changelog Description

I opened this issue #222 but realized that the build instructions were outdated. Now `package.json` is in the `website` folder so we need to cd into it and install the dependencies.

