### PR TITLE
Document editorial changes from January 2025.

### DIFF
--- a/website/docs/addon_flame_artist.md
+++ b/website/docs/addon_flame_artist.md
@@ -74,17 +74,45 @@ e.g. You can rename the clips, specify frame padding and etc.
 ![](assets/flame/artist/ayon_attribute_publish_creator.png)
 :::
 
-#### Vertical workflow
-* For a vertical workflow you need to first rename sequence tracks, so they can be used as product variant names. Just simply RMB click on the track and select _Rename Track_.
+In case you wish to publish reviewable video per `plate`:
+1. Enable the `review` toggle
+2. Select either the appropriate track name or `[clip's media]` (will use the clip own source)
+
+#### Vertical synchronization of attributes
+* This feature allows to publish multiple plate variant(s) per shot.
+* The timeline must contain multiple tracks one of those being the hero (driving) track. Per shot, the clip on the hero track will be driving the shot creation (shot length, shot resolution...).
+* You need to first rename sequence tracks, so they can be used as product variant names. Just simply RMB click on the track and select _Rename Track_.
 ![ayon_sequence_tracks_rename](assets/flame/artist/ayon_sequence_tracks_rename.png)
 ![ayon_vertical_alignment](assets/flame/artist/ayon_vertical_alignment.png)
 
-* In the **AYON Publish Attributes creator** window, enable _Enable Vertical Sync_ and select the _Hero track_ for Shot parenting. These hold the Shot metadata that needs to be distributed to other child clips, which are vertically aligned. Then in the _Product name_ set the option to `[track name]`
-![ayon_vertical_alignment_creator](assets/flame/artist/ayon_vertical_alignment_creator.png)
-* Confirm the changes by Create button and see that those clips were marked with the AYON marks.
+* To publish multiple plates for a shot process as following:
 
+1. Set up a multiple track timeline. Rename each track to determine plate variants (e.g `P01`, `P02` and `P03`)
+2. Pick-up one track the be the **hero** track and set your main plate clip onto it
+3. Then, for each shot, stack additional plate clip(s) on other tracks aligned with the hero/main plate clip. Clips can be shorter than the main hero track clip, but not longer.
+4. (Optional) You can setup another track to contain your review material
+5. Select all clips that needs to be published
+6. In the creator enable vertical align and select your main track as hero track
+5. Create instances by hitting "Create"
+6. Ensure all instances are parented to the same shot, which lenth is driven from the hero clip
+
+![ayon_vertical_alignment_creator](assets/flame/artist/ayon_vertical_alignment_creator.png)
+
+:::note
+If you are working with only two tracks where one track is going to be used as plates (e.g. `main`) and the other one holds video clips for offlines and web preview (e.g. `review`), then **Enable vertical sync** is not required.
+:::
 
 <!-- TODO: Add a note about publish plugins so that artists are aware of the changes that happens on publishing? -->
+
+### Speed retime and Timewarp
+
+Clip retiming via `TimeWarp` FX is supported. When such an effect is applied to a clip, it is automatically detected and stored as metadata for the relevant `plate` product.
+
+
+:::warning
+Autodesk Flame as some internal logic to compute retiming that can be extracted out of the software.
+AYON publisher rely on the logic from [FlameTimewarpML](https://github.com/talosh/flameTimewarpML) plugin to interpolate and gather the retiming. It works fine for most of the cases, but some limitations around speed-based timewarps and unusual curves are known. 
+:::
 
 ## Loading Products
 

--- a/website/docs/addon_hiero_artist.md
+++ b/website/docs/addon_hiero_artist.md
@@ -166,7 +166,9 @@ In case you wish to use *multiple elements of shots* workflow then ensure **Enab
 Product name is created dynamically if `<track_name>` is selected on **Product name**.
 <br></br>
 
-In case you wish to publish reviewable video as explained above, then find the appropriate track from drop down menu **Use review track**. Usually named `review`
+In case you wish to publish reviewable video per `plate`:
+1. Enable the `review` toggle
+2. Select either the appropriate track name or `[clip's media]` (will use the clip own source)
 <br></br>
 
 Hover above each input field for help.
@@ -198,10 +200,51 @@ Action the **Publish** button to trigger the publishing process for the active i
 </div>
 </div>
 
+### Vertical synchronization of product attributes
+
+This feature allows to publish multiple plate variant(s) per shot.
+
+The timeline must contain multiple tracks - as mentioned [here](#rename-timeline-track-names) one of those being the hero (driving) track.
+Per shot, the clip on the hero track will be driving the shot creation (shot length, shot resolution...)
+
+To publish multiple plates for a shot process as following:
+
+1. Set up a multiple track timeline. Rename each track to determine plate variants (e.g `L01`, `L02` and `L03`)
+2. Pick-up one track the be the **hero** track and set your main plate clip onto it
+3. Then, for each shot, stack additional plate clip(s) on other tracks aligned with the hero/main plate clip. Clips can be shorter than the main hero track clip, but not longer.
+4. (Optional) You can setup another track to contain your review material
+5. Select all clips that needs to be published
+6. In the creator enable vertical align and select your main track as hero track
+5. Create instances by hitting "Create"
+6. Ensure all instances are parented to the same shot, which lenth is driven from the hero clip
+
+:::note
+If you are working with only two tracks where one track is going to be used as plates (e.g. `main`) and the other one holds video clips for offlines and web preview (e.g. `review`), then **Enable vertical sync** is not required.
+:::
+
 ### Publishing Effects from Hiero to Nuke
+
+When publishing a `plate` from Hiero, the process can automatically detect and export associated editorial effects (e.g. `Timewarp`, `OCIOFileTransform`, `Text`...) as `effect` products. Those are json files that can be used further down the pipeline to recreate the look/result from Hiero.
+
 This video shows a way to publish shot look as effect from Hiero to Nuke.
 
 <iframe width="512px" height="288px" src="https://www.youtube.com/embed/HzZDdtII5io" frameborder="0" modestbranding="1" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>
+
+:::note
+If you are not interested in publishing `effects`, this feature can be opt out in the Publisher UI through a toggle on each `plate` product instance.
+:::
+
+### Restrict instances collection to current clip selection
+
+With long sequences, it is often the case that dozens (hundered?) of `plate`, `shot` and `audio` instances are created on a single timeline.
+
+In that case, republishing only part of the sequence might be challenging, once would need to go through the product instances list and manually enable/disable the relevant ones.
+
+To ease this corner case, the user can leverage the `ayon+settings://hiero/create/CollectShotClip/collectSelectedInstance` settings which, when enabled, restrict the product instance collection to the selected clips from the timeline.
+
+:::note
+If current selection does not contain any clip, then all instances are collected.
+:::
 
 ### Assembling edit from published shot versions
 

--- a/website/docs/addon_resolve_artist.md
+++ b/website/docs/addon_resolve_artist.md
@@ -170,11 +170,34 @@ Notice the relationship of following sections. Keys from **Shot Template Keyword
 </div>
 </div>
 
+### Reviewable source
+
+In case you wish to publish reviewable video per `plate`:
+1. Enable the `review` toggle
+2. Select either the appropriate track name or `[clip's media]` (will use the clip own source)
+
 ### Vertical synchronization of product attributes
 
-In case you are only working with two tracks on timeline where `main` track is going to be used as plates for compositors and `review` track holds mp4 clips for offlines and web preview. **Enable vertical sync** can be deactivated.
+This feature allows to publish multiple plate variant(s) per shot.
 
-In multiple tracks scenario - as mentioned [here](#rename-timeline-track-names) - it is recommended to activate **Enable vertical sync** and define the hero (driving) track to *main*. This will ensure that all of the clips on corresponding to the same shots will have the same publishing parameters.
+The timeline must contain multiple tracks - as mentioned [here](#rename-timeline-track-names) one of those being the hero (driving) track.
+Per shot, the clip on the hero track will be driving the shot creation (shot length, shot resolution...)
+
+To publish multiple plates for a shot process as following:
+
+1. Set up a multiple track timeline. Rename each track to determine plate variants (e.g `L01`, `L02` and `L03`)
+2. Pick-up one track the be the **hero** track and set your main plate clip onto it
+3. Then, for each shot, stack additional plate clip(s) on other tracks aligned with the hero/main plate clip. Clips can be shorter than the main hero track clip, but not longer.
+4. (Optional) You can setup another track to contain your review material
+5. Select all clips that needs to be published (with chocolate color)
+6. In the creator enable vertical align and select your main track as hero track
+5. Create instances by hitting "Create"
+6. Ensure all instances are parented to the same shot, which lenth is driven from the hero clip
+
+:::note
+If you are working with only two tracks where one track is going to be used as plates (e.g. `main`) and the other one holds video clips for offlines and web preview (e.g. `review`), then **Enable vertical sync** is not required.
+:::
+
 
 <br></br>
 


### PR DESCRIPTION
## Changelog Description

Document the following changes:
* Better explain the vertical align feature (Hiero/Flame/Resolve)
* Reviewable source instead of review track  (Hiero/Flame/Resolve)
* Restrict instance collection to selection (Hiero)
* Disable effects detection and publish (Hiero)
* TimeWarp FX support and limitations (Flame)

## Testing notes:
1. Built using `yarn start`
